### PR TITLE
Add initial execution and ROM loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ GB3000 is an experimental Game Boy emulator written in Rust. The goal of this
 project is to eventually provide an accurate and well-documented emulator while
 keeping the code as simple and approachable as possible.
 
-At this early stage the emulator only defines the CPU and memory structures and
-includes a minimal `main` that resets the CPU. More functionality will be added
-incrementally.
+At this early stage the emulator provides basic CPU and memory implementations
+and executes a very small set of instructions (like NOP and immediate loads).
+A ROM file can be provided on the command line and the emulator will execute a
+few instructions from it as a placeholder loop.
 
 ## Building
 
@@ -17,7 +18,7 @@ cargo build
 ## Running
 
 ```sh
-cargo run
+cargo run -- path/to/rom.gb
 ```
 
 ## Testing

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,17 +3,30 @@ mod memory;
 
 use cpu::Cpu;
 use memory::Memory;
+use std::env;
+use std::fs;
 
 /// Entry point for the emulator. Currently this only creates the CPU and memory
 /// structures and performs a single step as a placeholder.
 fn main() {
+    let args: Vec<String> = env::args().collect();
+    let rom_path = args.get(1);
+
     let mut cpu = Cpu::new();
     let mut memory = Memory::new();
 
-    cpu.reset();
-    // In the future we will load a ROM into memory here and run the emulation
-    // loop. For now we just perform a single no-op step.
-    cpu.step(&mut memory.data);
+    if let Some(path) = rom_path {
+        let rom = fs::read(path).expect("failed to read ROM");
+        memory.load_rom(&rom);
+    }
 
-    println!("CPU after reset: {:?}", cpu);
+    cpu.reset();
+
+    // Run a few instructions as a placeholder until a real emulation loop is
+    // implemented.
+    for _ in 0..100 {
+        cpu.step(&mut memory.data);
+    }
+
+    println!("CPU after execution: {:?}", cpu);
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -13,6 +13,14 @@ impl Memory {
         Self { data: [0; 0x10000] }
     }
 
+    /// Loads the given ROM bytes into memory starting at address 0.
+    ///
+    /// Any bytes beyond the 32KB cartridge ROM area (0x8000 bytes) are ignored.
+    pub fn load_rom(&mut self, rom: &[u8]) {
+        let len = rom.len().min(0x8000);
+        self.data[..len].copy_from_slice(&rom[..len]);
+    }
+
     /// Reads a byte from the given address.
     pub fn read_byte(&self, addr: u16) -> u8 {
         self.data[addr as usize]
@@ -33,6 +41,16 @@ mod tests {
         let mut mem = Memory::new();
         mem.write_byte(0xC000, 0x42);
         assert_eq!(mem.read_byte(0xC000), 0x42);
+    }
+
+    #[test]
+    fn load_rom_copies_bytes() {
+        let rom = vec![0xAA, 0xBB, 0xCC];
+        let mut mem = Memory::new();
+        mem.load_rom(&rom);
+        assert_eq!(mem.read_byte(0x0000), 0xAA);
+        assert_eq!(mem.read_byte(0x0001), 0xBB);
+        assert_eq!(mem.read_byte(0x0002), 0xCC);
     }
 }
 


### PR DESCRIPTION
## Summary
- implement minimal instruction decoding in `step`
- add ROM loading helper in `Memory`
- add simple command-line ROM loading and execution loop
- document new usage in README
- test new CPU and memory behaviour

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6863f82fefac83319ee141d9a991e74d